### PR TITLE
feat: snapshot-based voting using ERC20Votes

### DIFF
--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -8,6 +8,7 @@ contract Governance {
         address target;
         uint256 value;
         bytes data;
+        uint256 snapshotBlock;
         uint256 startBlock;
         uint256 endBlock;
         bool executed;
@@ -38,6 +39,7 @@ contract Governance {
             target: target,
             value: value,
             data: data,
+            snapshotBlock: block.number - 1,
             startBlock: block.number,
             endBlock: block.number + 20000,
             executed: false,

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -55,7 +55,8 @@ contract Governance {
         require(block.number <= p.endBlock, "voting ended");
         require(!hasVoted[proposalId][msg.sender], "already voted");
 
-        uint256 votes = token.balanceOf(msg.sender);
+        uint256 votes = token.getPastVotes(msg.sender, p.snapshotBlock);
+
         require(votes > 0, "no votes");
 
         hasVoted[proposalId][msg.sender] = true;
@@ -65,24 +66,21 @@ contract Governance {
     }
 
     function executeProposal(uint256 proposalId) external {
-    Proposal storage p = proposals[proposalId];
+        Proposal storage p = proposals[proposalId];
 
-    require(!p.executed, "already executed");
-    require(block.number > p.endBlock, "voting not ended");
-    require(p.forVotes > p.againstVotes, "proposal failed");
+        require(!p.executed, "already executed");
+        require(block.number > p.endBlock, "voting not ended");
+        require(p.forVotes > p.againstVotes, "proposal failed");
 
-    p.executed = true;
+        p.executed = true;
 
-    (bool ok, ) = p.target.call{value: p.value}(p.data);
-    require(ok, "execution failed");
-}
+        (bool ok, ) = p.target.call{value: p.value}(p.data);
+        require(ok, "execution failed");
+    }
 
-
-    function getProposal(uint256 proposalId)
-        public
-        view
-        returns (Proposal memory proposal)
-    {
-       proposal = proposals[proposalId];
+    function getProposal(
+        uint256 proposalId
+    ) public view returns (Proposal memory proposal) {
+        proposal = proposals[proposalId];
     }
 }

--- a/contracts/token/DAOToken.sol
+++ b/contracts/token/DAOToken.sol
@@ -1,20 +1,40 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
-contract DAOToken is ERC20 {
+contract DAOToken is ERC20Votes, ERC20Permit, Ownable {
     address public governance;
 
-    constructor() ERC20("SimpleDAO Token", "SDT") {}
+    constructor()
+        ERC20("SimpleDAO Token", "SDT")
+        ERC20Permit("SimpleDAO Token")
+        Ownable(msg.sender)
+    {}
 
-    function setGovernance(address _gov) external {
-        require(governance == address(0), "governance already set");
-        governance = _gov;
+    function setGovernance(address _governance) external onlyOwner {
+        governance = _governance;
     }
 
     function mint(address to, uint256 amount) external {
         require(msg.sender == governance, "not governance");
         _mint(to, amount);
+    }
+
+    /* Required overrides */
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    ) internal override(ERC20, ERC20Votes) {
+        super._update(from, to, value);
+    }
+
+    function nonces(
+        address owner
+    ) public view override(ERC20Permit, Nonces) returns (uint256) {
+        return super.nonces(owner);
     }
 }

--- a/test/SnapshotVoting.ts
+++ b/test/SnapshotVoting.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("Governance — Snapshot Voting", function () {
+  let token: any;
+  let governance: any;
+  let owner: any;
+  let alice: any;
+  let bob: any;
+
+  beforeEach(async () => {
+    [owner, alice, bob] = await ethers.getSigners();
+
+    /* Deploy Token with voting support */
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    token = await Token.deploy();
+    await token.waitForDeployment();
+
+    /* Deploy Governance */
+    const Governance = await ethers.getContractFactory("SimpleGovernance");
+    governance = await Governance.deploy(token.target);
+    await governance.waitForDeployment();
+
+    /* Mint tokens */
+    await token.mint(alice.address, ethers.parseEther("100"));
+
+    /* Delegate voting power */
+    await token.connect(alice).delegate(alice.address);
+  });
+
+  it("uses snapshot voting power", async () => {
+    /* Alice creates proposal */
+    const tx = await governance.connect(alice).propose(
+      "Snapshot voting proposal"
+    );
+    await tx.wait();
+
+    const proposalId = 1;
+
+    /* Capture snapshot block */
+    const proposal = await governance.proposals(proposalId);
+    const snapshotBlock = proposal.snapshotBlock;
+
+    /* Alice transfers tokens AFTER proposal creation */
+    await token.connect(alice).transfer(
+      bob.address,
+      ethers.parseEther("100")
+    );
+
+    /* Move to voting period */
+    await time.mine(1);
+
+    /* Alice votes */
+    await governance.connect(alice).vote(proposalId, true);
+
+    const updatedProposal = await governance.proposals(proposalId);
+
+    /* Voting power should be based on snapshot */
+    expect(updatedProposal.forVotes).to.equal(
+      ethers.parseEther("100")
+    );
+
+    /* Sanity check: current balance is zero */
+    expect(await token.balanceOf(alice.address)).to.equal(0n);
+
+    /* Sanity check: voting power at snapshot is preserved */
+    const pastVotes = await token.getPastVotes(
+      alice.address,
+      snapshotBlock
+    );
+    expect(pastVotes).to.equal(ethers.parseEther("100"));
+  });
+});


### PR DESCRIPTION
## Summary
Implements snapshot-based governance voting using ERC20Votes to prevent vote manipulation.

## Commits
-  [feat: migrate DAOToken to ERC20Votes](https://github.com/0xfandom/simple-DAO/pull/16/commits/29c45a2ec7291f5beafec0712bc05a27e4dad143)
- [feat: add snapshot block to governance proposals](https://github.com/0xfandom/simple-DAO/pull/16/commits/9693815970ebff5675b456ff41f45d99b3b69e97)
- [feat: use snapshot-based voting power via getPastVotes](https://github.com/0xfandom/simple-DAO/pull/16/commits/4326d1df59561da820beb4e570002e6ab66931e3)
- [Merge branch 'main' into 3-issue-3-implement-snapshot-based-voting](https://github.com/0xfandom/simple-DAO/pull/16/commits/50ac9fd1d65f0878bdf240a2e8d584efef881b8e)
- [test: add snapshot-based voting test](https://github.com/0xfandom/simple-DAO/pull/16/commits/79a6732adf03bc6224145de46bfcab921942d8ae)


## Motivation
Prevents governance attacks based on token transfers or flash loans.

Closes #3 