### PR TITLE
feat: enforce quorum for governance proposals

### DIFF
--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -21,11 +21,14 @@ contract Governance {
   mapping(uint256 => Proposal) private proposals;
   mapping(uint256 => mapping(address => bool)) public hasVoted;
 
-  uint256 public constant VOTING_PERIOD = 5 days;
+    uint256 public constant VOTING_PERIOD = 5 days;
+    uint256 public quorumBps; // e.g. 1000 = 10%
 
-  constructor(address _token) {
-    token = DAOToken(_token);
-  }
+    constructor(address _token, uint256 _quorumBps) {
+        require(_quorumBps > 0 && _quorumBps <= 10_000, "invalid quorum");
+        token = DAOToken(_token);
+        quorumBps = _quorumBps;
+    }
 
   function propose(
     address target,

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -4,31 +4,31 @@ pragma solidity ^0.8.20;
 import '../token/DAOToken.sol';
 
 contract Governance {
-    struct Proposal {
-        address target;
-        uint256 value;
-        bytes data;
-        uint256 snapshotBlock;
-        uint256 startBlock;
-        uint256 endBlock;
-        bool executed;
-        uint256 forVotes;
-        uint256 againstVotes;
-    }
+  struct Proposal {
+    address target;
+    uint256 value;
+    bytes data;
+    uint256 snapshotBlock;
+    uint256 startBlock;
+    uint256 endBlock;
+    bool executed;
+    uint256 forVotes;
+    uint256 againstVotes;
+  }
 
   DAOToken public token;
   uint256 public proposalCount;
   mapping(uint256 => Proposal) private proposals;
   mapping(uint256 => mapping(address => bool)) public hasVoted;
 
-    uint256 public constant VOTING_PERIOD = 5 days;
-    uint256 public quorumBps; // e.g. 1000 = 10%
+  uint256 public constant VOTING_PERIOD = 5 days;
+  uint256 public quorumBps; // e.g. 1000 = 10%
 
-    constructor(address _token, uint256 _quorumBps) {
-        require(_quorumBps > 0 && _quorumBps <= 10_000, "invalid quorum");
-        token = DAOToken(_token);
-        quorumBps = _quorumBps;
-    }
+  constructor(address _token, uint256 _quorumBps) {
+    require(_quorumBps > 0 && _quorumBps <= 10_000, 'invalid quorum');
+    token = DAOToken(_token);
+    quorumBps = _quorumBps;
+  }
 
   function propose(
     address target,
@@ -37,18 +37,18 @@ contract Governance {
   ) external returns (uint256) {
     require(token.balanceOf(msg.sender) > 0, 'no voting power');
 
-        proposalCount++;
-        proposals[proposalCount] = Proposal({
-            target: target,
-            value: value,
-            data: data,
-            snapshotBlock: block.number - 1,
-            startBlock: block.number,
-            endBlock: block.number + 20000,
-            executed: false,
-            forVotes: 0,
-            againstVotes: 0
-        });
+    proposalCount++;
+    proposals[proposalCount] = Proposal({
+      target: target,
+      value: value,
+      data: data,
+      snapshotBlock: block.number - 1,
+      startBlock: block.number,
+      endBlock: block.number + 20000,
+      executed: false,
+      forVotes: 0,
+      againstVotes: 0
+    });
 
     return proposalCount;
   }
@@ -58,9 +58,9 @@ contract Governance {
     require(block.number <= p.endBlock, 'voting ended');
     require(!hasVoted[proposalId][msg.sender], 'already voted');
 
-        uint256 votes = token.getPastVotes(msg.sender, p.snapshotBlock);
+    uint256 votes = token.getPastVotes(msg.sender, p.snapshotBlock);
 
-        require(votes > 0, "no votes");
+    require(votes > 0, 'no votes');
 
     hasVoted[proposalId][msg.sender] = true;
 
@@ -68,30 +68,34 @@ contract Governance {
     else p.againstVotes += votes;
   }
 
-    function executeProposal(uint256 proposalId) external {
-        Proposal storage p = proposals[proposalId];
+  function executeProposal(uint256 proposalId) external {
+    Proposal storage p = proposals[proposalId];
 
-        require(!p.executed, "already executed");
-        require(block.number > p.endBlock, "voting not ended");
-        require(p.forVotes > p.againstVotes, "proposal failed");
+    require(!p.executed, 'already executed');
+    require(block.number > p.endBlock, 'voting not ended');
 
-        p.executed = true;
+    uint256 totalVotes = p.forVotes + p.againstVotes;
 
-        (bool ok, ) = p.target.call{value: p.value}(p.data);
-        require(ok, "execution failed");
-    }
+    require(totalVotes >= quorumVotes(proposalId), 'quorum not reached');
+    require(p.forVotes > p.againstVotes, 'proposal failed');
 
-    function getProposal(
-        uint256 proposalId
-    ) public view returns (Proposal memory proposal) {
-        proposal = proposals[proposalId];
-    }
+    p.executed = true;
 
-    function quorumVotes(uint256 proposalId) public view returns (uint256) {
-        Proposal storage p = proposals[proposalId];
+    (bool ok, ) = p.target.call{value: p.value}(p.data);
+    require(ok, 'execution failed');
+  }
 
-        uint256 totalSupply = token.getPastTotalSupply(p.snapshotBlock);
+  function getProposal(
+    uint256 proposalId
+  ) public view returns (Proposal memory proposal) {
+    proposal = proposals[proposalId];
+  }
 
-        return (totalSupply * quorumBps) / 10_000;
-    }
+  function quorumVotes(uint256 proposalId) public view returns (uint256) {
+    Proposal storage p = proposals[proposalId];
+
+    uint256 totalSupply = token.getPastTotalSupply(p.snapshotBlock);
+
+    return (totalSupply * quorumBps) / 10_000;
+  }
 }

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -86,4 +86,12 @@ contract Governance {
     ) public view returns (Proposal memory proposal) {
         proposal = proposals[proposalId];
     }
+
+    function quorumVotes(uint256 proposalId) public view returns (uint256) {
+        Proposal storage p = proposals[proposalId];
+
+        uint256 totalSupply = token.getPastTotalSupply(p.snapshotBlock);
+
+        return (totalSupply * quorumBps) / 10_000;
+    }
 }

--- a/test/QuorumEnforcement.ts
+++ b/test/QuorumEnforcement.ts
@@ -1,0 +1,72 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@nomicfoundation/hardhat-network-helpers";
+
+describe("Governance — Quorum Enforcement", function () {
+  let token: any;
+  let governance: any;
+  let alice: any;
+  let bob: any;
+  let carol: any;
+
+  beforeEach(async () => {
+    [alice, bob, carol] = await ethers.getSigners();
+
+    /* Deploy governance token */
+    const Token = await ethers.getContractFactory("GovernanceToken");
+    token = await Token.deploy();
+    await token.waitForDeployment();
+
+    /* Deploy governance */
+    const Governance = await ethers.getContractFactory("Governance");
+    governance = await Governance.deploy(token.target);
+    await governance.waitForDeployment();
+
+    /* Mint and delegate */
+    await token.mint(alice.address, ethers.parseEther("100"));
+    await token.mint(bob.address, ethers.parseEther("100"));
+
+    await token.connect(alice).delegate(alice.address);
+    await token.connect(bob).delegate(bob.address);
+  });
+
+  it("fails if quorum is not met", async () => {
+    /* Alice creates proposal */
+    await governance.connect(alice).propose("Low quorum proposal");
+
+    const proposalId = 1;
+
+    /* Only Alice votes (assume quorum > 100) */
+    await governance.connect(alice).vote(proposalId, true);
+
+    /* Move past voting period */
+    await time.mine(20);
+
+    /* Execution should revert due to low quorum */
+    await expect(
+      governance.executeProposal(proposalId)
+    ).to.be.revertedWith("quorum not reached");
+  });
+
+  it("passes when quorum and majority are met", async () => {
+    /* Alice creates proposal */
+    await governance.connect(alice).propose("Valid quorum proposal");
+
+    const proposalId = 1;
+
+    /* Alice + Bob vote in favor */
+    await governance.connect(alice).vote(proposalId, true);
+    await governance.connect(bob).vote(proposalId, true);
+
+    /* Move past voting period */
+    await time.mine(20);
+
+    /* Execution should succeed */
+    await expect(
+      governance.executeProposal(proposalId)
+    ).to.not.be.reverted;
+
+    const proposal = await governance.proposals(proposalId);
+    expect(proposal.executed).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds quorum enforcement to governance proposals to prevent low-participation executions.

## Commits
- [feat: add configurable quorum parameter](https://github.com/0xfandom/simple-DAO/pull/17/commits/6853e473dab053f14f08b8a84cf361fb1e9eb76a)
- [feat: compute quorum votes using snapshot total supply](https://github.com/0xfandom/simple-DAO/pull/17/commits/9d66cc00f40e655e4a36d7799b332586a24d1854)
- [feat: enforce quorum requirement for proposal execution](https://github.com/0xfandom/simple-DAO/pull/17/commits/c4d0e704361776d5d0b8a9f0031deca892e6c268)
-  [test: add quorum enforcement tests](https://github.com/0xfandom/simple-DAO/pull/17/commits/b4b879b891acc1571e3f9ba0ae6d3ec4617de804)

## Motivation
Prevents governance capture through low-vote participation.

Closes #4 