### PR TITLE
feat: add ERC20 transfer support to treasury

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ A minimal AnyDAO-inspired governance protocol.
 ## Status
 
 ⚠️ Early development — not audited
+
+### Treasury Assets
+
+The DAO treasury can hold:
+- ETH
+- Any ERC20 token
+
+All transfers must be executed through governance proposals
+and are subject to quorum and timelock delays.
+

--- a/contracts/treasury/Treasury.sol
+++ b/contracts/treasury/Treasury.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {ReentrancyGuard} from '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+using SafeERC20 for IERC20;
+
 
 contract Treasury is ReentrancyGuard {
     // executor is typically the Timelock contract

--- a/contracts/treasury/Treasury.sol
+++ b/contracts/treasury/Treasury.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 using SafeERC20 for IERC20;
-
 
 contract Treasury is ReentrancyGuard {
     // executor is typically the Timelock contract
@@ -22,11 +21,19 @@ contract Treasury is ReentrancyGuard {
 
   receive() external payable {}
 
-  function transferETH(
-    address to,
-    uint256 amount
-  ) external onlyExecutor nonReentrant {
-    (bool ok, ) = to.call{value: amount}('');
-    require(ok, 'eth transfer failed');
-  }
+    function transferETH(
+        address to,
+        uint256 amount
+    ) external onlyExecutor nonReentrant {
+        (bool ok, ) = to.call{value: amount}("");
+        require(ok, "eth transfer failed");
+    }
+
+    function transferERC20(
+        address token,
+        address to,
+        uint256 amount
+    ) external onlyExecutor nonReentrant {
+        IERC20(token).safeTransfer(to, amount);
+    }
 }

--- a/test/GovernanceTreasuryERC20.ts
+++ b/test/GovernanceTreasuryERC20.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@openzeppelin/test-helpers";
+
+describe("Governance → Treasury ERC20 transfers", function () {
+  let token: any;
+  let governance: any;
+  let timelock: any;
+  let executor: any;
+  let treasury: any;
+  let erc20: any;
+
+  let deployer: any;
+  let alice: any;
+  let recipient: any;
+
+  beforeEach(async () => {
+    [deployer, alice, recipient] = await ethers.getSigners();
+
+    // Governance token
+    const GovToken = await ethers.getContractFactory("DAOToken");
+    token = await GovToken.deploy();
+    await token.waitForDeployment();
+
+    // ERC20 to be held by treasury
+    const ERC20 = await ethers.getContractFactory("MockERC20");
+    erc20 = await ERC20.deploy("Mock Token", "MOCK", 18);
+    await erc20.waitForDeployment();
+
+    // Timelock
+    const Timelock = await ethers.getContractFactory("DAOTimelock");
+    timelock = await Timelock.deploy(2 * 24 * 60 * 60, [], []);
+    await timelock.waitForDeployment();
+
+    // Governance
+    const Governance = await ethers.getContractFactory("Governance");
+    governance = await Governance.deploy(
+      await token.getAddress(),
+      1000,
+      await timelock.getAddress()
+    );
+    await governance.waitForDeployment();
+
+    // Executor
+    const Executor = await ethers.getContractFactory("Executor");
+    executor = await Executor.deploy(await governance.getAddress());
+    await executor.waitForDeployment();
+
+    // Treasury
+    const Treasury = await ethers.getContractFactory("Treasury");
+    treasury = await Treasury.deploy(await executor.getAddress());
+    await treasury.waitForDeployment();
+
+    // Roles
+    await timelock.grantRole(
+      await timelock.PROPOSER_ROLE(),
+      await governance.getAddress()
+    );
+    await timelock.grantRole(
+      await timelock.EXECUTOR_ROLE(),
+      await executor.getAddress()
+    );
+
+    // Voting power
+    await token.mint(alice.address, 100);
+
+    // Fund treasury with ERC20
+    await erc20.mint(await treasury.getAddress(), 1_000);
+  });
+
+  it("executes ERC20 transfer from treasury via governance proposal", async () => {
+    const amount = 250;
+
+    // Encode Treasury.transferERC20(...)
+    const data = treasury.interface.encodeFunctionData(
+      "transferERC20",
+      [
+        await erc20.getAddress(),
+        recipient.address,
+        amount
+      ]
+    );
+
+    // Propose
+    await governance
+      .connect(alice)
+      .propose(await treasury.getAddress(), 0, data);
+
+    await time.advanceBlock();
+
+    // Vote
+    await governance.connect(alice).vote(1, true);
+
+    // End voting
+    const proposal = await governance.getProposal(1);
+    await time.advanceBlockTo(Number(proposal.endBlock) + 1);
+
+    // Queue
+    await governance.queueProposal(1);
+
+    // Timelock delay
+    await time.increase(await timelock.getMinDelay());
+
+    // Execute
+    await executor.executeQueued(1);
+
+    expect(await erc20.balanceOf(recipient.address)).to.equal(amount);
+  });
+});

--- a/test/TreasuryERC20Security.ts
+++ b/test/TreasuryERC20Security.ts
@@ -1,0 +1,134 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@openzeppelin/test-helpers";
+
+describe("Treasury ERC20 security restrictions", function () {
+  let token: any;
+  let governance: any;
+  let timelock: any;
+  let executor: any;
+  let treasury: any;
+  let erc20: any;
+
+  let deployer: any;
+  let alice: any;
+  let recipient: any;
+
+  beforeEach(async () => {
+    [deployer, alice, recipient] = await ethers.getSigners();
+
+    // Governance token
+    const GovToken = await ethers.getContractFactory("DAOToken");
+    token = await GovToken.deploy();
+    await token.waitForDeployment();
+
+    // ERC20 to be held by treasury
+    const ERC20 = await ethers.getContractFactory("MockERC20");
+    erc20 = await ERC20.deploy("Mock Token", "MOCK", 18);
+    await erc20.waitForDeployment();
+
+    // Timelock
+    const Timelock = await ethers.getContractFactory("DAOTimelock");
+    timelock = await Timelock.deploy(2 * 24 * 60 * 60, [], []);
+    await timelock.waitForDeployment();
+
+    // Governance
+    const Governance = await ethers.getContractFactory("Governance");
+    governance = await Governance.deploy(
+      await token.getAddress(),
+      1000,
+      await timelock.getAddress()
+    );
+    await governance.waitForDeployment();
+
+    // Executor
+    const Executor = await ethers.getContractFactory("Executor");
+    executor = await Executor.deploy(await governance.getAddress());
+    await executor.waitForDeployment();
+
+    // Treasury
+    const Treasury = await ethers.getContractFactory("Treasury");
+    treasury = await Treasury.deploy(await executor.getAddress());
+    await treasury.waitForDeployment();
+
+    // Roles
+    await timelock.grantRole(
+      await timelock.PROPOSER_ROLE(),
+      await governance.getAddress()
+    );
+    await timelock.grantRole(
+      await timelock.EXECUTOR_ROLE(),
+      await executor.getAddress()
+    );
+
+    // Voting power
+    await token.mint(alice.address, 100);
+
+    // Fund treasury with ERC20
+    await erc20.mint(await treasury.getAddress(), 1_000);
+  });
+
+  it("EOA cannot transfer ERC20 from treasury", async () => {
+    await expect(
+      treasury
+        .connect(alice)
+        .transferERC20(
+          await erc20.getAddress(),
+          recipient.address,
+          100
+        )
+    ).to.be.revertedWith("not executor");
+  });
+
+  it("Governance cannot bypass timelock to transfer ERC20", async () => {
+    await expect(
+      treasury
+        .connect(governance)
+        .transferERC20(
+          await erc20.getAddress(),
+          recipient.address,
+          100
+        )
+    ).to.be.revertedWith("not executor");
+  });
+
+  it("ERC20 transfer succeeds only via timelock execution", async () => {
+    const amount = 300;
+
+    const data = treasury.interface.encodeFunctionData(
+      "transferERC20",
+      [
+        await erc20.getAddress(),
+        recipient.address,
+        amount
+      ]
+    );
+
+    // Propose
+    await governance
+      .connect(alice)
+      .propose(await treasury.getAddress(), 0, data);
+
+    await time.advanceBlock();
+
+    // Vote
+    await governance.connect(alice).vote(1, true);
+
+    // End voting
+    const proposal = await governance.getProposal(1);
+    await time.advanceBlockTo(Number(proposal.endBlock) + 1);
+
+    // Queue
+    await governance.queueProposal(1);
+
+    // Timelock delay
+    await time.increase(await timelock.getMinDelay());
+
+    // Execute
+    await executor.executeQueued(1);
+
+    expect(
+      await erc20.balanceOf(recipient.address)
+    ).to.equal(amount);
+  });
+});


### PR DESCRIPTION
## Summary
Adds SafeERC20-based ERC20 transfer support to the DAO treasury, restricted to timelock-controlled governance execution.

## Commits
- feat: add ERC20 transfer support to treasury
- feat: allow governance proposals to transfer ERC20 tokens
- test: add ERC20 treasury transfer tests
- docs: document ERC20 treasury support

## Security
- Executor-only access
- NonReentrant
- Timelock enforced
- No admin or EOA privileges

Closes #7 