### PR TITLE
feat: add proposal threshold to governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ The DAO treasury can hold:
 All transfers must be executed through governance proposals
 and are subject to quorum and timelock delays.
 
+### Proposal Threshold
+
+To prevent spam proposals, proposers must hold at least a
+configurable percentage of total voting power at snapshot time.
+
+

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -23,16 +23,18 @@ contract Governance {
   mapping(uint256 => Proposal) private proposals;
   mapping(uint256 => mapping(address => bool)) public hasVoted;
 
-  uint256 public constant VOTING_PERIOD = 5 days;
-  uint256 public quorumBps; // e.g. 1000 = 10%
-  DAOTimelock public timelock;
+    uint256 public constant VOTING_PERIOD = 5 days;
+    uint256 public quorumBps; // e.g. 1000 = 10%
+    DAOTimelock public timelock;
+    uint256 public proposalThresholdBps;
 
-  constructor(address _token, uint256 _quorumBps, DAOTimelock _timelock) {
-    require(_quorumBps > 0 && _quorumBps <= 10_000, 'invalid quorum');
-    token = DAOToken(_token);
-    quorumBps = _quorumBps;
-    timelock = _timelock;
-  }
+    constructor(address _token, uint256 _quorumBps, DAOTimelock _timelock, uint256 _proposalThresholdBps) {
+        require(_quorumBps > 0 && _quorumBps <= 10_000, "invalid quorum");
+        token = DAOToken(_token);
+        quorumBps = _quorumBps;
+        timelock = _timelock;
+        proposalThresholdBps = _proposalThresholdBps;
+    }
 
   function propose(
     address target,

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -28,7 +28,12 @@ contract Governance {
     DAOTimelock public timelock;
     uint256 public proposalThresholdBps;
 
-    constructor(address _token, uint256 _quorumBps, DAOTimelock _timelock, uint256 _proposalThresholdBps) {
+    constructor(
+        address _token,
+        uint256 _quorumBps,
+        DAOTimelock _timelock,
+        uint256 _proposalThresholdBps
+    ) {
         require(_quorumBps > 0 && _quorumBps <= 10_000, "invalid quorum");
         token = DAOToken(_token);
         quorumBps = _quorumBps;
@@ -43,19 +48,29 @@ contract Governance {
   ) external returns (uint256) {
     require(token.balanceOf(msg.sender) > 0, 'no voting power');
 
-    proposalCount++;
-    proposals[proposalCount] = Proposal({
-      target: target,
-      value: value,
-      data: data,
-      snapshotBlock: block.number - 1,
-      startBlock: block.number,
-      endBlock: block.number + 20000,
-      queued: false,
-      executed: false,
-      forVotes: 0,
-      againstVotes: 0
-    });
+        uint256 snapshotBlock = block.number - 1;
+
+        uint256 proposerVotes = token.getPastVotes(msg.sender, snapshotBlock);
+
+        uint256 totalSupply = token.getPastTotalSupply(snapshotBlock);
+
+        uint256 thresholdVotes = (totalSupply * proposalThresholdBps) / 10_000;
+
+        require(proposerVotes >= thresholdVotes, "proposal threshold not met");
+
+        proposalCount++;
+        proposals[proposalCount] = Proposal({
+            target: target,
+            value: value,
+            data: data,
+            snapshotBlock: snapshotBlock,
+            startBlock: block.number,
+            endBlock: block.number + 20000,
+            queued: false,
+            executed: false,
+            forVotes: 0,
+            againstVotes: 0
+        });
 
     return proposalCount;
   }

--- a/test/ProposalThreshold.ts
+++ b/test/ProposalThreshold.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { time } from "@openzeppelin/test-helpers";
+
+describe("Governance — proposal threshold enforcement", function () {
+  let token: any;
+  let governance: any;
+  let timelock: any;
+
+  let deployer: any;
+  let user: any;
+  let whale: any;
+  let target: any;
+
+  beforeEach(async () => {
+    [deployer, user, whale, target] = await ethers.getSigners();
+
+    // Deploy governance token
+    const DAOToken = await ethers.getContractFactory("DAOToken");
+    token = await DAOToken.deploy();
+    await token.waitForDeployment();
+
+    // Deploy timelock
+    const Timelock = await ethers.getContractFactory("DAOTimelock");
+    timelock = await Timelock.deploy(2 * 24 * 60 * 60, [], []);
+    await timelock.waitForDeployment();
+
+    // Deploy governance
+    const Governance = await ethers.getContractFactory("Governance");
+    governance = await Governance.deploy(
+      await token.getAddress(),
+      1000, // quorum = 10%
+      await timelock.getAddress()
+    );
+    await governance.waitForDeployment();
+  });
+
+  it("❌ reverts when proposer is below proposal threshold", async () => {
+    // User has small balance
+    await token.mint(user.address, 5);
+
+    const data = "0x";
+
+    await expect(
+      governance
+        .connect(user)
+        .propose(target.address, 0, data)
+    ).to.be.revertedWith("proposal threshold not met");
+  });
+
+  it("✅ allows proposal when proposer meets threshold", async () => {
+    // Whale has enough voting power
+    await token.mint(whale.address, 1_000);
+
+    const data = "0x";
+
+    await governance
+      .connect(whale)
+      .propose(target.address, 0, data);
+
+    expect(await governance.proposalCount()).to.equal(1);
+  });
+
+  it("❌ transferring tokens after snapshot does NOT affect proposal eligibility", async () => {
+    // Whale initially meets threshold
+    await token.mint(whale.address, 1_000);
+
+    // Create snapshot boundary
+    await time.advanceBlock();
+
+    // Transfer tokens away AFTER snapshot
+    await token.connect(whale).transfer(user.address, 900);
+
+    const data = "0x";
+
+    // Proposal should still succeed
+    await governance
+      .connect(whale)
+      .propose(target.address, 0, data);
+
+    expect(await governance.proposalCount()).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a proposal threshold requirement to prevent spam governance proposals.

## Commits
- feat: add proposal threshold configuration
- feat: enforce proposal threshold at proposal creation

## Security
- Snapshot-based voting power
- Prevents flash-loan proposals
- Configurable threshold

Closes #8 
